### PR TITLE
add cleanup of dangling images (merge spotify/docker-gc master)

### DIFF
--- a/docker-gc
+++ b/docker-gc
@@ -255,6 +255,9 @@ do
     | uniq >> images.all
 done
 
+# Add dangling images to list.
+$DOCKER images --no-trunc --format "{{.ID}}" --filter dangling=true >> images.all
+
 # Find images that are created at least GRACE_PERIOD_SECONDS ago
 > images.reap.tmp
 cat images.all | sort | uniq | while read line


### PR DESCRIPTION
We have an issue with a lot of  dangling images, this is actually fixed on the maser